### PR TITLE
FPS info, audio-only media support and retry backoff

### DIFF
--- a/src/core/src/entities/level.ts
+++ b/src/core/src/entities/level.ts
@@ -1,11 +1,12 @@
-export class Level {
-  constructor(
-    readonly id: string,
-    readonly playlistID: string,
-    readonly uri: string,
-    readonly index: number,
-    readonly width?: number,
-    readonly height?: number,
-    readonly bitrate?: number,
-  ) {}
-}
+export type LevelType = "stream" | "audio";
+
+export type Level = {
+  type: LevelType;
+  id: string;
+  playlistID: string;
+  uri: string;
+  width?: number;
+  height?: number;
+  bitrate?: number;
+  fps?: number;
+};

--- a/src/core/src/entities/level.ts
+++ b/src/core/src/entities/level.ts
@@ -1,12 +1,14 @@
 export type LevelType = "stream" | "audio";
 
-export type Level = {
-  type: LevelType;
-  id: string;
-  playlistID: string;
-  uri: string;
-  width?: number;
-  height?: number;
-  bitrate?: number;
-  fps?: number;
-};
+export class Level {
+  constructor(
+    readonly type: LevelType,
+    readonly id: string,
+    readonly playlistID: string,
+    readonly uri: string,
+    readonly width?: number,
+    readonly height?: number,
+    readonly bitrate?: number,
+    readonly fps?: number
+  ) {}
+}

--- a/src/core/src/services/parser.ts
+++ b/src/core/src/services/parser.ts
@@ -5,6 +5,5 @@ export interface IParser {
   parseLevelPlaylist(
     string: string,
     baseurl: string,
-    index: number
   ): Fragment[];
 }

--- a/src/core/src/use-cases/get-fragments-details.ts
+++ b/src/core/src/use-cases/get-fragments-details.ts
@@ -13,7 +13,6 @@ export const getFragmentsDetailsFactory = (
     const fragments = parser.parseLevelPlaylist(
       levelPlaylistText,
       playlist.uri,
-      playlist.index
     );
     return fragments;
   };

--- a/src/extension/extension-background/package-lock.json
+++ b/src/extension/extension-background/package-lock.json
@@ -13,7 +13,7 @@
         "@types/uuid": "^7.0.2",
         "@videojs/vhs-utils": "^1.3.0",
         "idb": "6.1.2",
-        "m3u8-parser": "^4.4.0",
+        "m3u8-parser": "^6.2.0",
         "sanitize-filename": "^1.6.3",
         "ts-loader": "^8.0.2",
         "url-toolkit": "^2.1.6",
@@ -47,10 +47,14 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.9.2",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -1159,10 +1163,27 @@
       }
     },
     "node_modules/m3u8-parser": {
-      "version": "4.4.0",
-      "integrity": "sha512-iH2AygTFILtato+XAgnoPYzLHM4R3DjATj7Ozbk7EHdB2XoLF2oyOUguM7Kc4UVHbQHHL/QPaw98r7PbWzG0gg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-6.2.0.tgz",
+      "integrity": "sha512-qlC00JTxYOxawcqg+RB8jbyNwL3foY/nCY61kyWP+RCuJE9APLeqB/nSlTjb4Mg0yRmyERgjswpdQxMvkeoDrg==",
       "dependencies": {
-        "global": "^4.3.2"
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0"
+      }
+    },
+    "node_modules/m3u8-parser/node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
       }
     },
     "node_modules/make-dir": {
@@ -1535,8 +1556,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.5",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -1944,8 +1966,9 @@
       }
     },
     "node_modules/url-toolkit": {
-      "version": "2.1.6",
-      "integrity": "sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
+      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.4",
@@ -2275,10 +2298,11 @@
   },
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.9.2",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@discoveryjs/json-ext": {
@@ -3180,10 +3204,25 @@
       }
     },
     "m3u8-parser": {
-      "version": "4.4.0",
-      "integrity": "sha512-iH2AygTFILtato+XAgnoPYzLHM4R3DjATj7Ozbk7EHdB2XoLF2oyOUguM7Kc4UVHbQHHL/QPaw98r7PbWzG0gg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-6.2.0.tgz",
+      "integrity": "sha512-qlC00JTxYOxawcqg+RB8jbyNwL3foY/nCY61kyWP+RCuJE9APLeqB/nSlTjb4Mg0yRmyERgjswpdQxMvkeoDrg==",
       "requires": {
-        "global": "^4.3.2"
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0"
+      },
+      "dependencies": {
+        "@videojs/vhs-utils": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+          "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "global": "^4.4.0",
+            "url-toolkit": "^2.2.1"
+          }
+        }
       }
     },
     "make-dir": {
@@ -3475,8 +3514,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "resolve": {
       "version": "1.22.0",
@@ -3764,8 +3804,9 @@
       }
     },
     "url-toolkit": {
-      "version": "2.1.6",
-      "integrity": "sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
+      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
     },
     "utf8-byte-length": {
       "version": "1.0.4",

--- a/src/extension/extension-background/package.json
+++ b/src/extension/extension-background/package.json
@@ -21,7 +21,7 @@
     "@types/uuid": "^7.0.2",
     "@videojs/vhs-utils": "^1.3.0",
     "idb": "6.1.2",
-    "m3u8-parser": "^4.4.0",
+    "m3u8-parser": "^6.2.0",
     "sanitize-filename": "^1.6.3",
     "ts-loader": "^8.0.2",
     "url-toolkit": "^2.1.6",

--- a/src/extension/extension-background/src/services/fetch-loader.ts
+++ b/src/extension/extension-background/src/services/fetch-loader.ts
@@ -8,13 +8,14 @@ async function fetchWithRetry<Data>(
     throw new Error("Attempts less then 1");
   }
   let countdown = attempts;
+  let retryTime = 100;
   while (countdown--) {
     try {
       return await fetchFn();
     } catch (e) {
       if (countdown < 1 && countdown < attempts) {
-        const retryTime = 100;
         await new Promise((resolve) => setTimeout(resolve, retryTime));
+        retryTime *= 1.15;
       }
     }
   }

--- a/src/extension/extension-background/src/services/m3u8-parser.d.ts
+++ b/src/extension/extension-background/src/services/m3u8-parser.d.ts
@@ -42,6 +42,7 @@ declare module "m3u8-parser" {
         width: number;
         height: number;
       };
+      "FRAME-RATE"?: number;
     };
   };
 

--- a/src/extension/extension-background/src/services/m3u8-parser.ts
+++ b/src/extension/extension-background/src/services/m3u8-parser.ts
@@ -28,30 +28,35 @@ export const M3u8Parser: IParser = {
     const parser = new Parser();
     parser.push(string);
     const playlists = parser.manifest?.playlists ?? [];
-    const results = playlists.map(playlist => ({
-      type: 'stream' as LevelType,
+    const audioPlaylists = parser.manifest?.mediaGroups?.AUDIO ?? {};
+    const results = playlists.map((playlist) => ({
+      type: "stream" as LevelType,
       id: v4(),
       playlistID: baseurl,
       uri: buildAbsoluteURL(baseurl, playlist.uri),
       bitrate: playlist.attributes.BANDWIDTH,
-      fps: playlist.attributes['FRAME-RATE'],
+      fps: playlist.attributes["FRAME-RATE"],
       height: playlist.attributes.RESOLUTION?.height,
       width: playlist.attributes.RESOLUTION?.width,
     }));
-    for (const [key, entries] of Object.entries(parser.manifest?.mediaGroups?.AUDIO ?? {})) {
-      for (const [label, entry] of Object.entries(entries)) {
-        results.push({
-          type: 'audio' as LevelType,
-          id: `${label}-${key}`,
-          playlistID: baseurl,
-          uri: buildAbsoluteURL(baseurl, entry.uri),
-          bitrate: undefined,
-          fps: undefined,
-          width: undefined,
-          height: undefined,
+
+    const audioResults = Object.entries(audioPlaylists).flatMap(
+      ([key, entries]) => {
+        return Object.entries(entries).map(([label, entry]) => {
+          return {
+            type: "audio" as LevelType,
+            id: `${label}-${key}`,
+            playlistID: baseurl,
+            uri: buildAbsoluteURL(baseurl, entry.uri),
+            bitrate: undefined,
+            fps: undefined,
+            width: undefined,
+            height: undefined,
+          };
         });
       }
-    }
-    return results;
+    );
+
+    return results.concat(audioResults);
   },
 };

--- a/src/extension/extension-background/src/services/m3u8-parser.ts
+++ b/src/extension/extension-background/src/services/m3u8-parser.ts
@@ -1,6 +1,6 @@
 /// <reference path="m3u8-parser.d.ts" />
 
-import { Fragment, Level } from "@hls-downloader/core/lib/entities";
+import { Fragment, Level, LevelType } from "@hls-downloader/core/lib/entities";
 import { IParser } from "@hls-downloader/core/lib/services";
 import { Parser } from "m3u8-parser";
 import { buildAbsoluteURL } from "url-toolkit";
@@ -28,14 +28,30 @@ export const M3u8Parser: IParser = {
     const parser = new Parser();
     parser.push(string);
     const playlists = parser.manifest?.playlists ?? [];
-    return playlists.map((playlist, index) => ({
-      index,
+    const results = playlists.map(playlist => ({
+      type: 'stream' as LevelType,
       id: v4(),
       playlistID: baseurl,
+      uri: buildAbsoluteURL(baseurl, playlist.uri),
       bitrate: playlist.attributes.BANDWIDTH,
+      fps: playlist.attributes['FRAME-RATE'],
       height: playlist.attributes.RESOLUTION?.height,
       width: playlist.attributes.RESOLUTION?.width,
-      uri: buildAbsoluteURL(baseurl, playlist.uri),
     }));
+    for (const [key, entries] of Object.entries(parser.manifest?.mediaGroups?.AUDIO ?? {})) {
+      for (const [label, entry] of Object.entries(entries)) {
+        results.push({
+          type: 'audio' as LevelType,
+          id: `${label}-${key}`,
+          playlistID: baseurl,
+          uri: buildAbsoluteURL(baseurl, entry.uri),
+          bitrate: undefined,
+          fps: undefined,
+          width: undefined,
+          height: undefined,
+        });
+      }
+    }
+    return results;
   },
 };

--- a/src/extension/extension-popup/src/view/LevelMetadata.tsx
+++ b/src/extension/extension-popup/src/view/LevelMetadata.tsx
@@ -1,0 +1,41 @@
+import { Grid, Stack, Text } from "@chakra-ui/react";
+import { Level } from "@hls-downloader/core/lib/entities";
+import React from "react";
+
+export function LevelMetadata(props: { level: Level }) {
+  if (props.level.type === "stream") {
+    return (
+      <Grid gridTemplateColumns="1.3fr 1fr 0.3fr" gridTemplateRows="1fr">
+        <Stack isInline spacing="0.4rem">
+          <Text color="#99a3ff">Stream</Text>
+          {props.level.width && (
+            <Text color="gray.400">
+              {props.level.width}×{props.level.height}
+            </Text>
+          )}
+        </Stack>
+        <Stack isInline spacing="0.4rem">
+          <Text color="#99a3ff">Bitrate</Text>
+          <Text color="gray.400">
+            {((props.level?.bitrate || 0) / 1024 / 1024).toFixed(1)} mbps
+          </Text>
+        </Stack>
+        <Stack isInline spacing="0.4rem">
+          <Text color="#99a3ff">FPS</Text>
+          <Text color="gray.400">{props.level.fps}</Text>
+        </Stack>
+      </Grid>
+    );
+  }
+  if (props.level.type === "audio") {
+    return (
+      <Grid gridTemplateColumns="1.3fr 1fr 0.3fr" gridTemplateRows="1fr">
+        <Stack isInline spacing="0.4rem">
+          <Text color="#99a3ff">Audio</Text>
+          <Text color="gray.400">{props.level.id}</Text>
+        </Stack>
+      </Grid>
+    );
+  }
+  return null;
+}

--- a/src/extension/extension-popup/src/view/LevelView.tsx
+++ b/src/extension/extension-popup/src/view/LevelView.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import { DownloadIcon } from "@chakra-ui/icons";
 
+
 export const LevelView = (props: { level: Level }) => {
   const dispatch = useDispatch();
   const { push } = useHistory();
@@ -15,6 +16,40 @@ export const LevelView = (props: { level: Level }) => {
     push("/downloads");
   }
 
+  let metaData;
+  if (props.level.type === 'stream') {
+    metaData = (
+      <Grid gridTemplateColumns="1.3fr 1fr 0.3fr" gridTemplateRows="1fr">
+        <Stack isInline spacing="0.4rem">
+          <Text color="#99a3ff">Stream</Text>
+          {props.level.width && (
+            <Text color="gray.400">
+              {props.level.width}×{props.level.height}
+            </Text>
+          )}
+        </Stack>
+        <Stack isInline spacing="0.4rem">
+          <Text color="#99a3ff">Bitrate</Text>
+          <Text color="gray.400">{((props.level?.bitrate || 0) / 1024 / 1024).toFixed(1)} mbps</Text>
+        </Stack>
+        <Stack isInline spacing="0.4rem">
+          <Text color="#99a3ff">FPS</Text>
+          <Text color="gray.400">{props.level.fps}</Text>
+        </Stack>
+      </Grid>
+    );
+  } else if (props.level.type === 'audio') {
+    metaData = (
+      <Grid gridTemplateColumns="1.3fr 1fr 0.3fr" gridTemplateRows="1fr">
+        <Stack isInline spacing="0.4rem">
+          <Text color="#99a3ff">Audio</Text>
+          <Text color="gray.400">{props.level.id}</Text>
+        </Stack>
+      </Grid>
+    );
+  } else {
+    throw new TypeError('invalid type');
+  }
   return (
     <Grid
       rounded="lg"
@@ -24,20 +59,7 @@ export const LevelView = (props: { level: Level }) => {
       bg="gray.800"
     >
       <Stack>
-        <Grid gridTemplateColumns="1.3fr 1fr 1fr" gridTemplateRows="1fr">
-          <Stack isInline spacing="0.4rem">
-            <Text color="#99a3ff">Resolution</Text>
-            {props.level.width && (
-              <Text color="gray.400">
-                {props.level.width}×{props.level.height}
-              </Text>
-            )}
-          </Stack>
-          <Stack isInline spacing="0.4rem">
-            <Text color="#99a3ff">Bitrate</Text>
-            <Text color="gray.400">{props.level.bitrate}</Text>
-          </Stack>
-        </Grid>
+        {metaData}
         <Box>
           <Input
             size="sm"

--- a/src/extension/extension-popup/src/view/LevelView.tsx
+++ b/src/extension/extension-popup/src/view/LevelView.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import { DownloadIcon } from "@chakra-ui/icons";
-
+import { LevelMetadata } from "./LevelMetadata";
 
 export const LevelView = (props: { level: Level }) => {
   const dispatch = useDispatch();
@@ -16,40 +16,6 @@ export const LevelView = (props: { level: Level }) => {
     push("/downloads");
   }
 
-  let metaData;
-  if (props.level.type === 'stream') {
-    metaData = (
-      <Grid gridTemplateColumns="1.3fr 1fr 0.3fr" gridTemplateRows="1fr">
-        <Stack isInline spacing="0.4rem">
-          <Text color="#99a3ff">Stream</Text>
-          {props.level.width && (
-            <Text color="gray.400">
-              {props.level.width}×{props.level.height}
-            </Text>
-          )}
-        </Stack>
-        <Stack isInline spacing="0.4rem">
-          <Text color="#99a3ff">Bitrate</Text>
-          <Text color="gray.400">{((props.level?.bitrate || 0) / 1024 / 1024).toFixed(1)} mbps</Text>
-        </Stack>
-        <Stack isInline spacing="0.4rem">
-          <Text color="#99a3ff">FPS</Text>
-          <Text color="gray.400">{props.level.fps}</Text>
-        </Stack>
-      </Grid>
-    );
-  } else if (props.level.type === 'audio') {
-    metaData = (
-      <Grid gridTemplateColumns="1.3fr 1fr 0.3fr" gridTemplateRows="1fr">
-        <Stack isInline spacing="0.4rem">
-          <Text color="#99a3ff">Audio</Text>
-          <Text color="gray.400">{props.level.id}</Text>
-        </Stack>
-      </Grid>
-    );
-  } else {
-    throw new TypeError('invalid type');
-  }
   return (
     <Grid
       rounded="lg"
@@ -59,7 +25,7 @@ export const LevelView = (props: { level: Level }) => {
       bg="gray.800"
     >
       <Stack>
-        {metaData}
+        <LevelMetadata level={props.level} />
         <Box>
           <Input
             size="sm"


### PR DESCRIPTION
 * Include the FPS on the playlist "levels".
 * Show Bitrate as mbps
 * Include audio-only media group entries which are used for some multilingual broadcasts
 * Remove unused `Level.index` which complicated piggy backing on playlists
 * Include backoff into the retry algo instead of doing 100ms loop that keeps throttled requests stuck in that state.

WARNING: I have little to no experience with anything React related.