### PR TITLE
Reduce redux saveState overhead

### DIFF
--- a/src/extension/extension-background/package-lock.json
+++ b/src/extension/extension-background/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
+        "@github/mini-throttle": "^2.1.0",
         "@hls-downloader/core": "file:../../core",
         "@types/uuid": "^7.0.2",
         "@videojs/vhs-utils": "^1.3.0",
@@ -60,6 +61,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@github/mini-throttle": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@github/mini-throttle/-/mini-throttle-2.1.0.tgz",
+      "integrity": "sha512-iEeR2OdVCPkdIPUszL8gJnKNu4MR8ANh7y0u/LPyaatYezgaWxUZEzhFntloqQq+HE6MZkFy+cl+xzCNuljOdw=="
     },
     "node_modules/@hls-downloader/core": {
       "resolved": "../../core",
@@ -2285,6 +2291,11 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
       "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA=="
+    },
+    "@github/mini-throttle": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@github/mini-throttle/-/mini-throttle-2.1.0.tgz",
+      "integrity": "sha512-iEeR2OdVCPkdIPUszL8gJnKNu4MR8ANh7y0u/LPyaatYezgaWxUZEzhFntloqQq+HE6MZkFy+cl+xzCNuljOdw=="
     },
     "@hls-downloader/core": {
       "version": "file:../../core",

--- a/src/extension/extension-background/package.json
+++ b/src/extension/extension-background/package.json
@@ -17,6 +17,7 @@
     "typescript": "3.8.3"
   },
   "dependencies": {
+    "@github/mini-throttle": "^2.1.0",
     "@hls-downloader/core": "file:../../core",
     "@types/uuid": "^7.0.2",
     "@videojs/vhs-utils": "^1.3.0",

--- a/src/extension/extension-background/src/index.ts
+++ b/src/extension/extension-background/src/index.ts
@@ -21,8 +21,10 @@ import { M3u8Parser } from "./services/m3u8-parser";
 
   wrapStore(store);
 
+  let bufferSaveState : number;
   store.subscribe(() => {
-    saveState(store.getState());
+    window.clearTimeout(bufferSaveState);
+    bufferSaveState = window.setTimeout(() => saveState(store.getState()), 200);
   });
 
   subscribeListeners(store);

--- a/src/extension/extension-background/src/index.ts
+++ b/src/extension/extension-background/src/index.ts
@@ -6,6 +6,7 @@ import { CryptoDecryptor } from "./services/crypto-decryptor";
 import { FetchLoader } from "./services/fetch-loader";
 import { IndexedDBFS } from "./services/indexedb-fs";
 import { M3u8Parser } from "./services/m3u8-parser";
+import { throttle } from "@github/mini-throttle";
 
 (async () => {
   const state = await getState();
@@ -21,10 +22,8 @@ import { M3u8Parser } from "./services/m3u8-parser";
 
   wrapStore(store);
 
-  let bufferSaveState : number;
   store.subscribe(() => {
-    window.clearTimeout(bufferSaveState);
-    bufferSaveState = window.setTimeout(() => saveState(store.getState()), 200);
+    throttle(saveState, 100);
   });
 
   subscribeListeners(store);

--- a/src/extension/extension-background/src/persistState.ts
+++ b/src/extension/extension-background/src/persistState.ts
@@ -1,7 +1,8 @@
 import { browser } from "webextension-polyfill-ts";
 import { RootState } from "@hls-downloader/core/lib/adapters/redux/root-reducer";
 
-export async function saveState(state: RootState) {
+export async function saveState() {
+  const state = getState();
   if (!state) {
     return;
   }


### PR DESCRIPTION
I noticed my CPU was quite high when downloading big streams and most of the CPU was being spent doing browser.storage.local.set(...) for saving the state.  This state only appears to be needed when the background page is reloaded (which will never happen if the a content-script is active.

Buffering the save by 200ms reduces JS overhead by about ~40% (not including native methods overhead) and total CPU usage on my system (circa 2022 AMD 16 core) is reduced by ~28%.


Attaching 10s profile captures before(unbuffered) and after (buffered):

[hls-perf-traces.tar.gz](https://github.com/puemos/hls-downloader/files/12008950/hls-perf-traces.tar.gz)
