### PR TITLE
Fix fetch retry logic

### DIFF
--- a/src/background/src/services/fetch-loader.ts
+++ b/src/background/src/services/fetch-loader.ts
@@ -13,7 +13,7 @@ async function fetchWithRetry<Data>(
     try {
       return await fetchFn();
     } catch (e) {
-      if (countdown < 1 && countdown < attempts) {
+      if (countdown > 0) {
         await new Promise((resolve) => setTimeout(resolve, retryTime));
         retryTime *= 1.15;
       }


### PR DESCRIPTION
## Summary
- fix retry logic in FetchLoader to allow retries before exhausting attempts

## Testing
- `npm run --prefix src/core build`
- `npm ci --prefix src/background`
- `npm run --prefix src/background build`
- `sh ./scripts/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6884abb210308324b5dbdc8cb56cf29d