### PR TITLE
Remove leftover console logs

### DIFF
--- a/src/design-system/src/hooks/use-localstorage.ts
+++ b/src/design-system/src/hooks/use-localstorage.ts
@@ -14,7 +14,7 @@ export function useLocalStorage(key: string, initialValue: any) {
       return item ? JSON.parse(item) : initialValue;
     } catch (error) {
       // If error also return initialValue
-      console.log(error);
+      console.error(error);
       return initialValue;
     }
   });
@@ -33,7 +33,7 @@ export function useLocalStorage(key: string, initialValue: any) {
       }
     } catch (error) {
       // A more advanced implementation would handle the error case
-      console.log(error);
+      console.error(error);
     }
   };
   return [storedValue, setValue];

--- a/src/popup/src/modules/Navbar/RouterController.ts
+++ b/src/popup/src/modules/Navbar/RouterController.ts
@@ -13,7 +13,6 @@ const useRouterController = (): ReturnType => {
   const [tab, setTab] = useLocalStorage("view", DEFAULT_TAB);
 
   function safeSetTab(tab: string) {
-    console.log("Setting tab to", tab);
 
     if (
       [


### PR DESCRIPTION
## Summary
- remove leftover console.log from RouterController
- switch error logging in useLocalStorage hook to console.error

## Testing
- `npm test` *(fails: Could not find package.json)*
- `npm run build` in packages

------
https://chatgpt.com/codex/tasks/task_e_6884b8a8e6a0832480514028c9238f4c