### PR TITLE
Improve red dot accuracy

### DIFF
--- a/src/background/src/listeners/addPlaylistListener.ts
+++ b/src/background/src/listeners/addPlaylistListener.ts
@@ -8,22 +8,39 @@ import {
 } from "webextension-polyfill";
 
 export function addPlaylistListener(store: ReturnType<typeof createStore>) {
-  webRequest.onResponseStarted.addListener(
+  webRequest.onHeadersReceived.addListener(
     async (details) => {
       if (details.tabId < 0) {
         return;
       }
+
+      const contentTypeHeader = details.responseHeaders?.find(
+        (h) => h.name.toLowerCase() === "content-type",
+      );
+
+      const contentType = contentTypeHeader?.value?.toLowerCase() || "";
+
+      if (
+        !contentType.includes("application/vnd.apple.mpegurl") &&
+        !contentType.includes("application/x-mpegurl")
+      ) {
+        return;
+      }
+
+      if (
+        details.statusCode &&
+        (details.statusCode < 200 || details.statusCode >= 300)
+      ) {
+        return;
+      }
+
+      const playlistExists =
+        !!store.getState().playlists.playlists[details.url];
+
+      if (playlistExists) {
+        return;
+      }
       const tab = await tabs.get(details.tabId);
-      const action = actiobV2 || actiobV3;
-      await action.setIcon({
-        tabId: tab.id,
-        path: {
-          "16": "assets/icons/16-new.png",
-          "48": "assets/icons/48-new.png",
-          "128": "assets/icons/128-new.png",
-          "256": "assets/icons/256-new.png",
-        },
-      });
 
       store.dispatch(
         playlistsSlice.actions.addPlaylist({
@@ -34,6 +51,26 @@ export function addPlaylistListener(store: ReturnType<typeof createStore>) {
           createdAt: Date.now(),
         }),
       );
+
+      const unsubscribe = store.subscribe(() => {
+        const status =
+          store.getState().playlists.playlistsStatus[details.url]?.status;
+        if (status === "ready") {
+          const action = actiobV2 || actiobV3;
+          void action.setIcon({
+            tabId: tab.id,
+            path: {
+              "16": "assets/icons/16-new.png",
+              "48": "assets/icons/48-new.png",
+              "128": "assets/icons/128-new.png",
+              "256": "assets/icons/256-new.png",
+            },
+          });
+          unsubscribe();
+        } else if (status === "error") {
+          unsubscribe();
+        }
+      });
     },
     {
       types: ["xmlhttprequest"],
@@ -44,5 +81,6 @@ export function addPlaylistListener(store: ReturnType<typeof createStore>) {
         "https://*/*.m3u8?*",
       ],
     },
+    ["responseHeaders"],
   );
 }


### PR DESCRIPTION
## Summary
- verify successful response and avoid duplicates when capturing playlists
- only set browser action icon after storing a new playlist
- show the icon only when playlist fetch succeeds

## Testing
- `pnpm install`
- `sh ./scripts/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68864cc49458832486eb01549a9c6116