### PR TITLE
Refine popup UI

### DIFF
--- a/src/popup/src/App.tsx
+++ b/src/popup/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
   return (
     <div
       id="hls-downloader-ext"
-      className="w-[500px] h-[600px] transition-all p-4 font-sans antialiased "
+      className="w-[500px] h-[600px] transition-all p-4 font-sans antialiased rounded-xl shadow-lg bg-background"
     >
       <RouterModule></RouterModule>
     </div>

--- a/src/popup/src/modules/Direct/DirectView.tsx
+++ b/src/popup/src/modules/Direct/DirectView.tsx
@@ -47,13 +47,12 @@ const DirectView = ({
         <div className="flex flex-row items-center justify-between gap-2">
           <Input
             type="text"
-            className="p-2 border rounded-md"
             placeholder="https://.../playlist.m3u8"
             value={directURI}
             onChange={(e) => setDirectURI(e.target.value)}
           />
           <Button
-            size={"default"}
+            size="sm"
             variant="secondary"
             onClick={addDirectPlaylist}
           >
@@ -62,7 +61,7 @@ const DirectView = ({
         </div>
       )}
       {!currentPlaylistId && playlists.length === 0 && (
-        <div className="flex flex-col items-center justify-center pt-36">
+        <div className="flex flex-col items-center justify-center py-20">
           <Banana></Banana>
 
           <h3 className="mt-4 text-lg font-semibold">No videos</h3>
@@ -77,7 +76,7 @@ const DirectView = ({
             <div
               key={item.id}
               className={cn(
-                "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm",
+                "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm hover:bg-muted",
               )}
             >
               <div className="flex flex-col w-full gap-1">
@@ -89,9 +88,11 @@ const DirectView = ({
                     {new Date(item.createdAt!).toLocaleString()}
                   </div>
                 </div>
-                <div className="text-xs font-medium">{item.initiator}</div>
+                <div className="text-xs font-medium truncate" title={item.initiator}>
+                  {item.initiator}
+                </div>
               </div>
-              <div className="text-xs break-all text-muted-foreground">
+              <div className="text-xs text-muted-foreground truncate" title={item.uri}>
                 {item.uri}
               </div>
               <div className="flex flex-row-reverse w-full">

--- a/src/popup/src/modules/Downloads/DownloadsView.tsx
+++ b/src/popup/src/modules/Downloads/DownloadsView.tsx
@@ -37,7 +37,7 @@ const DownloadsView = ({
         </>
       )}
       {!currentJobId && jobs.length === 0 && (
-        <div className="flex flex-col items-center justify-center mt-32">
+        <div className="flex flex-col items-center justify-center py-20">
           <TreePine></TreePine>
 
           <h3 className="mt-4 text-lg font-semibold">
@@ -52,7 +52,6 @@ const DownloadsView = ({
         <div className="flex flex-row items-center justify-between gap-2">
           <Input
             type="text"
-            className="p-2 border rounded-md"
             placeholder="Filter downloads..."
             value={filter}
             onChange={(e) => setFilter(e.target.value)}

--- a/src/popup/src/modules/Job/JobView.tsx
+++ b/src/popup/src/modules/Job/JobView.tsx
@@ -34,7 +34,7 @@ const JobView = ({
   return (
     <div
       className={cn(
-        "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm min-w-0 overflow-hidden"
+        "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm min-w-0 overflow-hidden hover:bg-muted"
       )}
     >
       <div className="flex flex-col items-start justify-between w-full mb-1 min-w-0">

--- a/src/popup/src/modules/Navbar/RouterView.tsx
+++ b/src/popup/src/modules/Navbar/RouterView.tsx
@@ -19,7 +19,7 @@ const RouterView = () => {
   return (
     <Tabs value={tab} defaultValue={tab} onValueChange={setTab}>
       <div className="flex justify-center">
-        <TabsList>
+        <TabsList className="mb-4">
           <TabsTrigger value={TabOptions.SNIFTER}>Sniffer</TabsTrigger>
           <TabsTrigger value={TabOptions.DIRECT}>Direct</TabsTrigger>
           <TabsTrigger value={TabOptions.DOWNLOADS}>Downloads</TabsTrigger>

--- a/src/popup/src/modules/Sniffer/SnifferView.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferView.tsx
@@ -38,10 +38,10 @@ const SnifferView = ({
         </>
       )}
       {!currentPlaylistId && playlists.length === 0 && (
-        <div className="flex flex-col items-center justify-center mt-32">
+        <div className="flex flex-col items-center justify-center py-20">
           <Banana></Banana>
 
-          <h3 className="mt-4 text-lg font-semibold">No video were found</h3>
+          <h3 className="mt-4 text-lg font-semibold">No videos found</h3>
           <p className="mt-2 mb-4 text-sm text-muted-foreground">
             Try visiting a website with video and try again.
           </p>
@@ -51,12 +51,11 @@ const SnifferView = ({
         <div className="flex flex-row items-center justify-between gap-2">
           <Input
             type="text"
-            className="p-2 border rounded-md"
             placeholder="Filter playlists..."
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
           />
-          <Button size={"default"} variant="secondary" onClick={clearPlaylists}>
+          <Button size="sm" variant="secondary" onClick={clearPlaylists}>
             Clear all
           </Button>
         </div>
@@ -67,7 +66,7 @@ const SnifferView = ({
             <div
               key={item.id}
               className={cn(
-                "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm"
+                "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm hover:bg-muted"
               )}
             >
               <div className="flex flex-col w-full gap-1">
@@ -79,16 +78,12 @@ const SnifferView = ({
                     {new Date(item.createdAt!).toLocaleString()}
                   </div>
                 </div>
-                <div className="text-xs font-medium">
-                  {item.initiator && item.initiator.length > 70
-                    ? item.initiator.substring(0, 70) + "..."
-                    : item.initiator}
+                <div className="text-xs font-medium truncate" title={item.initiator}>
+                  {item.initiator}
                 </div>
               </div>
-              <div className="text-xs break-all text-muted-foreground">
-                {item.uri && item.uri.length > 70
-                  ? item.uri.substring(0, 70) + "..."
-                  : item.uri}
+              <div className="text-xs text-muted-foreground truncate" title={item.uri}>
+                {item.uri}
               </div>
               <div className="flex flex-row-reverse w-full">
                 <Button


### PR DESCRIPTION
## Summary
- polish popup container styling
- adjust Direct, Sniffer and Downloads views for consistency
- improve playlist and job item readability
- tweak navigation tab spacing

## Testing
- `pnpm install`
- `sh ./scripts/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_688651f5a8588324b4354018e80730a3