### PR TITLE
Refine popup styling

### DIFF
--- a/src/popup/src/App.tsx
+++ b/src/popup/src/App.tsx
@@ -7,7 +7,7 @@ function App() {
   return (
     <div
       id="hls-downloader-ext"
-      className="w-[500px] h-[600px] transition-all p-4 font-sans antialiased "
+      className="w-[500px] h-[600px] transition-all p-4 font-sans antialiased rounded-xl shadow-lg bg-card border"
     >
       <RouterModule></RouterModule>
     </div>

--- a/src/popup/src/modules/About/AboutView.tsx
+++ b/src/popup/src/modules/About/AboutView.tsx
@@ -7,8 +7,8 @@ interface Props {
 
 const AboutView = ({ version }: Props) => {
   return (
-    <div className="flex flex-col p-1 mt-4 space-y-3">
-      <div className="flex items-center justify-between h-16 p-3 border rounded-sm shrink-0">
+    <div className="flex flex-col p-2 mt-4 space-y-4">
+      <div className="flex items-center justify-between h-16 p-3 border rounded-md shrink-0">
         <div>
           <p className="text-sm font-semibold">
             <span aria-label="plant" role="img" className="mr-2">
@@ -19,7 +19,7 @@ const AboutView = ({ version }: Props) => {
         </div>
         <div className="text-sm font-semibold">{version}</div>
       </div>
-      <div className="flex items-center justify-between h-16 p-3 border rounded-sm shrink-0">
+      <div className="flex items-center justify-between h-16 p-3 border rounded-md shrink-0">
         <div>
           <p className="text-sm font-semibold">
             <span aria-label="plant" role="img" className="mr-2">

--- a/src/popup/src/modules/Direct/DirectView.tsx
+++ b/src/popup/src/modules/Direct/DirectView.tsx
@@ -30,7 +30,7 @@ const DirectView = ({
   const showFilterInput = playlists.length !== 0;
 
   return (
-    <div className="flex flex-col p-1 mt-4 space-y-3">
+    <div className="flex flex-col p-2 mt-4 space-y-4">
       {currentPlaylistId && (
         <>
           <Button
@@ -44,16 +44,16 @@ const DirectView = ({
         </>
       )}
       {!currentPlaylistId && (
-        <div className="flex flex-row items-center justify-between gap-2">
+        <div className="flex flex-row items-center gap-2">
           <Input
             type="text"
-            className="p-2 border rounded-md"
+            className="flex-grow"
             placeholder="https://.../playlist.m3u8"
             value={directURI}
             onChange={(e) => setDirectURI(e.target.value)}
           />
           <Button
-            size={"default"}
+            size="sm"
             variant="secondary"
             onClick={addDirectPlaylist}
           >
@@ -62,7 +62,7 @@ const DirectView = ({
         </div>
       )}
       {!currentPlaylistId && playlists.length === 0 && (
-        <div className="flex flex-col items-center justify-center pt-36">
+        <div className="flex flex-col items-center justify-center py-20">
           <Banana></Banana>
 
           <h3 className="mt-4 text-lg font-semibold">No videos</h3>
@@ -77,7 +77,7 @@ const DirectView = ({
             <div
               key={item.id}
               className={cn(
-                "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm",
+                "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm hover:bg-muted bg-card",
               )}
             >
               <div className="flex flex-col w-full gap-1">
@@ -89,9 +89,11 @@ const DirectView = ({
                     {new Date(item.createdAt!).toLocaleString()}
                   </div>
                 </div>
-                <div className="text-xs font-medium">{item.initiator}</div>
+                <div className="text-xs font-medium truncate" title={item.initiator}>
+                  {item.initiator}
+                </div>
               </div>
-              <div className="text-xs break-all text-muted-foreground">
+              <div className="text-xs text-muted-foreground truncate" title={item.uri}>
                 {item.uri}
               </div>
               <div className="flex flex-row-reverse w-full">

--- a/src/popup/src/modules/Downloads/DownloadsView.tsx
+++ b/src/popup/src/modules/Downloads/DownloadsView.tsx
@@ -23,7 +23,7 @@ const DownloadsView = ({
   const showFilterInput = jobs.length !== 0;
 
   return (
-    <div className="flex flex-col p-1 mt-4 space-y-3">
+    <div className="flex flex-col p-2 mt-4 space-y-4">
       {currentJobId && (
         <>
           <Button
@@ -37,7 +37,7 @@ const DownloadsView = ({
         </>
       )}
       {!currentJobId && jobs.length === 0 && (
-        <div className="flex flex-col items-center justify-center mt-32">
+        <div className="flex flex-col items-center justify-center py-20">
           <TreePine></TreePine>
 
           <h3 className="mt-4 text-lg font-semibold">
@@ -49,10 +49,10 @@ const DownloadsView = ({
         </div>
       )}
       {!currentJobId && jobs.length > 0 && showFilterInput && (
-        <div className="flex flex-row items-center justify-between gap-2">
+        <div className="flex flex-row items-center gap-2">
           <Input
             type="text"
-            className="p-2 border rounded-md"
+            className="flex-grow"
             placeholder="Filter downloads..."
             value={filter}
             onChange={(e) => setFilter(e.target.value)}

--- a/src/popup/src/modules/Job/JobView.tsx
+++ b/src/popup/src/modules/Job/JobView.tsx
@@ -34,7 +34,7 @@ const JobView = ({
   return (
     <div
       className={cn(
-        "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm min-w-0 overflow-hidden"
+        "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm min-w-0 overflow-hidden hover:bg-muted bg-card"
       )}
     >
       <div className="flex flex-col items-start justify-between w-full mb-1 min-w-0">

--- a/src/popup/src/modules/Navbar/RouterView.tsx
+++ b/src/popup/src/modules/Navbar/RouterView.tsx
@@ -19,7 +19,7 @@ const RouterView = () => {
   return (
     <Tabs value={tab} defaultValue={tab} onValueChange={setTab}>
       <div className="flex justify-center">
-        <TabsList>
+        <TabsList className="mb-4 gap-1">
           <TabsTrigger value={TabOptions.SNIFTER}>Sniffer</TabsTrigger>
           <TabsTrigger value={TabOptions.DIRECT}>Direct</TabsTrigger>
           <TabsTrigger value={TabOptions.DOWNLOADS}>Downloads</TabsTrigger>

--- a/src/popup/src/modules/Settings/SettingsView.tsx
+++ b/src/popup/src/modules/Settings/SettingsView.tsx
@@ -23,8 +23,8 @@ const SettingsView = ({
   onSaveDialogToggle,
 }: Props) => {
   return (
-    <div className="flex flex-col p-1 mt-4 space-y-3">
-      <div className="flex items-center justify-between h-16 p-3 border rounded-sm shrink-0">
+    <div className="flex flex-col p-2 mt-4 space-y-4">
+      <div className="flex items-center justify-between h-16 p-3 border rounded-md shrink-0">
         <div>
           <p className="text-sm font-semibold">Concurrency</p>
         </div>
@@ -49,7 +49,7 @@ const SettingsView = ({
         </div>
       </div>
 
-      <div className="flex items-center justify-between h-16 p-3 border rounded-sm shrink-0">
+      <div className="flex items-center justify-between h-16 p-3 border rounded-md shrink-0">
         <div>
           <p className="text-sm font-semibold">Fetch Attempts</p>
         </div>
@@ -78,7 +78,7 @@ const SettingsView = ({
         </div>
       </div>
 
-      <div className="flex items-center justify-between h-16 p-3 border rounded-sm shrink-0">
+      <div className="flex items-center justify-between h-16 p-3 border rounded-md shrink-0">
         <div>
           <p className="text-sm font-semibold">Save Dialog</p>
         </div>

--- a/src/popup/src/modules/Sniffer/SnifferView.tsx
+++ b/src/popup/src/modules/Sniffer/SnifferView.tsx
@@ -24,7 +24,7 @@ const SnifferView = ({
   const showFilterInput = playlists.length !== 0;
 
   return (
-    <div className="flex flex-col p-1 mt-4 space-y-3">
+    <div className="flex flex-col p-2 mt-4 space-y-4">
       {currentPlaylistId && (
         <>
           <Button
@@ -38,25 +38,25 @@ const SnifferView = ({
         </>
       )}
       {!currentPlaylistId && playlists.length === 0 && (
-        <div className="flex flex-col items-center justify-center mt-32">
+        <div className="flex flex-col items-center justify-center py-20">
           <Banana></Banana>
 
-          <h3 className="mt-4 text-lg font-semibold">No video were found</h3>
+          <h3 className="mt-4 text-lg font-semibold">No videos found</h3>
           <p className="mt-2 mb-4 text-sm text-muted-foreground">
             Try visiting a website with video and try again.
           </p>
         </div>
       )}
       {!currentPlaylistId && playlists.length > 0 && showFilterInput && (
-        <div className="flex flex-row items-center justify-between gap-2">
+        <div className="flex flex-row items-center gap-2">
           <Input
             type="text"
-            className="p-2 border rounded-md"
+            className="flex-grow"
             placeholder="Filter playlists..."
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
           />
-          <Button size={"default"} variant="secondary" onClick={clearPlaylists}>
+          <Button size="sm" variant="secondary" onClick={clearPlaylists}>
             Clear all
           </Button>
         </div>
@@ -67,7 +67,7 @@ const SnifferView = ({
             <div
               key={item.id}
               className={cn(
-                "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm"
+                "flex flex-col mb-2 items-start gap-2 rounded-lg border p-3 text-left text-sm hover:bg-muted bg-card"
               )}
             >
               <div className="flex flex-col w-full gap-1">
@@ -79,16 +79,12 @@ const SnifferView = ({
                     {new Date(item.createdAt!).toLocaleString()}
                   </div>
                 </div>
-                <div className="text-xs font-medium">
-                  {item.initiator && item.initiator.length > 70
-                    ? item.initiator.substring(0, 70) + "..."
-                    : item.initiator}
+                <div className="text-xs font-medium truncate" title={item.initiator}>
+                  {item.initiator}
                 </div>
               </div>
-              <div className="text-xs break-all text-muted-foreground">
-                {item.uri && item.uri.length > 70
-                  ? item.uri.substring(0, 70) + "..."
-                  : item.uri}
+              <div className="text-xs text-muted-foreground truncate" title={item.uri}>
+                {item.uri}
               </div>
               <div className="flex flex-row-reverse w-full">
                 <Button


### PR DESCRIPTION
## Summary
- polish container style and add subtle borders
- balance spacing in all views
- improve hover and truncate behavior for playlists and jobs
- tweak tab layout spacing

## Testing
- `pnpm install`
- `sh ./scripts/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_688651f5a8588324b4354018e80730a3