### PR TITLE
Use tabs API for About view report link

### DIFF
--- a/src/popup/src/modules/About/AboutView.tsx
+++ b/src/popup/src/modules/About/AboutView.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@hls-downloader/design-system";
 import React from "react";
+import { tabs } from "webextension-polyfill";
 
 interface Props {
   version: string;
@@ -9,7 +10,7 @@ interface Props {
 
 const AboutView = ({ version, name, description }: Props) => {
   const open = (url: string) => {
-    window.open(url, "_blank");
+    tabs.create({ url });
   };
   return (
     <div className="flex flex-col p-1 mt-4 space-y-2">


### PR DESCRIPTION
## Summary
- use `tabs.create` from `webextension-polyfill` in AboutView to open report link in new tab

## Testing
- `pnpm install`
- `sh ./scripts/build.sh`
- Report button opens GitHub issues in a new tab in Chrome and Firefox


------
close #409