### PR TITLE
Expand core test coverage

### DIFF
--- a/src/core/test/add-download-job-epic.test.ts
+++ b/src/core/test/add-download-job-epic.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { addDownloadJobEpic } from '../src/controllers/add-download-job-epic.ts';
+import { levelsSlice } from '../src/store/slices/levels-slice.ts';
+import { jobsSlice } from '../src/store/slices/index.ts';
+import { Playlist, Level, Fragment, Key } from '../src/entities/index.ts';
+
+describe('addDownloadJobEpic', () => {
+  it('creates a download job for selected levels', async () => {
+    const videoLevel = new Level('stream', 'v', 'p', 'video', 1920, 1080, 1000);
+    const audioLevel = new Level('audio', 'a', 'p', 'audio');
+    const playlist = new Playlist('p', 'http://example.com/master.m3u8', Date.now(), 'page');
+    const videoFragment = new Fragment(new Key(null, null), 'vf', 0);
+    const audioFragment = new Fragment(new Key(null, null), 'af', 0);
+
+    const loader = { fetchText: vi.fn().mockResolvedValue('') };
+    const parser = {
+      parseLevelPlaylist: vi
+        .fn()
+        .mockImplementation((_text, uri) =>
+          uri === 'video' ? [videoFragment] : [audioFragment],
+        ),
+    };
+    const deps = { loader, parser };
+
+    const action$ = of(
+      levelsSlice.actions.download({ levelID: 'v', audioLevelID: 'a' }),
+    );
+    const state = {
+      levels: { levels: { v: videoLevel, a: audioLevel } },
+      playlists: { playlists: { p: playlist } },
+      config: { fetchAttempts: 1, concurrency: 2, saveDialog: false },
+      tabs: { current: { id: -1 } },
+      jobs: { jobs: {}, jobsStatus: {} },
+    };
+
+    const result = await firstValueFrom(
+      addDownloadJobEpic(action$, { value: state } as any, deps as any),
+    );
+
+    expect(result.type).toBe(jobsSlice.actions.add.type);
+    expect(result.payload.job.filename).toBe('page-master.mp4');
+    expect(result.payload.job.videoFragments).toEqual([videoFragment]);
+    expect(result.payload.job.audioFragments).toEqual([audioFragment]);
+    expect(result.payload.job.bitrate).toBe(1000);
+    expect(result.payload.job.width).toBe(1920);
+    expect(result.payload.job.height).toBe(1080);
+    expect(result.payload.job.id).toMatch(/^page-master.mp4\//);
+  });
+});
+

--- a/src/core/test/add-playlist-epic.test.ts
+++ b/src/core/test/add-playlist-epic.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { addPlaylistEpic } from '../src/controllers/add-playlist-epic.ts';
+import { playlistsSlice } from '../src/store/slices/index.ts';
+import { Playlist } from '../src/entities/index.ts';
+
+describe('addPlaylistEpic', () => {
+  it('fetches playlist levels when playlist exists', async () => {
+    const playlist = new Playlist('1', 'uri', Date.now());
+    const action$ = of(playlistsSlice.actions.addPlaylist(playlist));
+    const state = {
+      playlists: {
+        playlists: { '1': playlist },
+        playlistsStatus: {},
+      },
+      levels: { levels: {} },
+      config: { concurrency: 2, saveDialog: false, fetchAttempts: 1 },
+      tabs: { current: { id: -1 } },
+      jobs: { jobs: {}, jobsStatus: {} },
+    };
+    const result = await firstValueFrom(
+      addPlaylistEpic(action$, { value: state } as any, {} as any),
+    );
+    expect(result).toEqual(
+      playlistsSlice.actions.fetchPlaylistLevels({ playlistID: '1' }),
+    );
+  });
+});
+

--- a/src/core/test/cancel-job-delete-job-epic.test.ts
+++ b/src/core/test/cancel-job-delete-job-epic.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { cancelJobdeleteJobEpic } from '../src/controllers/cancel-job-delete-job-epic.ts';
+import { jobsSlice } from '../src/store/slices/index.ts';
+
+describe('cancelJobdeleteJobEpic', () => {
+  it('dispatches delete when job is canceled', async () => {
+    const action$ = of(jobsSlice.actions.cancel({ jobId: '1' }));
+    const result = await firstValueFrom(
+      cancelJobdeleteJobEpic(action$, {} as any, { fs: {} } as any),
+    );
+    expect(result).toEqual(jobsSlice.actions.delete({ jobId: '1' }));
+  });
+});
+

--- a/src/core/test/delete-job-epic.test.ts
+++ b/src/core/test/delete-job-epic.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { deleteJobEpic } from '../src/controllers/delete-job-epic.ts';
+import { jobsSlice } from '../src/store/slices/index.ts';
+
+describe('deleteJobEpic', () => {
+  it('deletes job bucket and emits success', async () => {
+    const fs = { deleteBucket: vi.fn().mockResolvedValue(undefined) };
+    const action$ = of(jobsSlice.actions.delete({ jobId: '1' }));
+    const result = await firstValueFrom(
+      deleteJobEpic(action$, {} as any, { fs } as any),
+    );
+    expect(fs.deleteBucket).toHaveBeenCalledWith('1');
+    expect(result).toEqual(jobsSlice.actions.deleteSuccess({ jobId: '1' }));
+  });
+});
+

--- a/src/core/test/download-job-epic.test.ts
+++ b/src/core/test/download-job-epic.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { downloadJobEpic } from '../src/controllers/download-job-epic.ts';
+import { jobsSlice } from '../src/store/slices/index.ts';
+import { Fragment, Key } from '../src/entities/index.ts';
+
+describe('downloadJobEpic', () => {
+  it('downloads fragments and reports progress', async () => {
+    const fragment = new Fragment(new Key(null, null), 'f', 0);
+    const job = {
+      id: '1',
+      videoFragments: [fragment],
+      audioFragments: [],
+      filename: 'file.mp4',
+      createdAt: Date.now(),
+      bitrate: 1000,
+      width: 640,
+      height: 360,
+    };
+    const fs = {
+      createBucket: vi.fn().mockResolvedValue(undefined),
+      getBucket: vi.fn().mockResolvedValue({
+        write: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+    const loader = {
+      fetchArrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+    };
+    const decryptor = { decrypt: vi.fn() };
+    const action$ = of(jobsSlice.actions.add({ job }));
+    const state = { config: { concurrency: 1, fetchAttempts: 1 } };
+    const result = await firstValueFrom(
+      downloadJobEpic(action$, { value: state } as any, {
+        fs,
+        loader,
+        decryptor,
+      } as any),
+    );
+    expect(fs.createBucket).toHaveBeenCalledWith('1', 1, 0);
+    expect(result).toEqual(
+      jobsSlice.actions.incDownloadStatus({ jobId: '1' }),
+    );
+  });
+});
+

--- a/src/core/test/fetch-playlist-levels-epic.test.ts
+++ b/src/core/test/fetch-playlist-levels-epic.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { toArray } from 'rxjs/operators';
+import { fetchPlaylistLevelsEpic } from '../src/controllers/fetch-playlist-levels-epic.ts';
+import { playlistsSlice } from '../src/store/slices/index.ts';
+import { levelsSlice } from '../src/store/slices/levels-slice.ts';
+import { Playlist, Level } from '../src/entities/index.ts';
+
+describe('fetchPlaylistLevelsEpic', () => {
+  it('loads levels for playlist', async () => {
+    const playlist = new Playlist('1', 'uri', Date.now());
+    const level = new Level('stream', 'l', '1', 'lu');
+    const loader = { fetchText: vi.fn().mockResolvedValue('') };
+    const parser = { parseMasterPlaylist: vi.fn().mockReturnValue([level]) };
+    const action$ = of(
+      playlistsSlice.actions.fetchPlaylistLevels({ playlistID: '1' }),
+    );
+    const state = {
+      playlists: { playlists: { '1': playlist } },
+      config: { fetchAttempts: 1 },
+    };
+    const result = await firstValueFrom(
+      fetchPlaylistLevelsEpic(action$, { value: state } as any, {
+        loader,
+        parser,
+      } as any).pipe(toArray()),
+    );
+    expect(result).toEqual([
+      playlistsSlice.actions.fetchPlaylistLevelsSuccess({ playlistID: '1' }),
+      levelsSlice.actions.add({ levels: [level] }),
+    ]);
+  });
+});
+

--- a/src/core/test/inc-download-status-epic.test.ts
+++ b/src/core/test/inc-download-status-epic.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { toArray } from 'rxjs/operators';
+import { incDownloadStatusEpic } from '../src/controllers/inc-download-status-epic.ts';
+import { jobsSlice } from '../src/store/slices/index.ts';
+
+describe('incDownloadStatusEpic', () => {
+  it('finishes and saves job when complete', async () => {
+    const state = {
+      jobs: { jobsStatus: { '1': { done: 1, total: 1 } }, jobs: {} },
+    };
+    const action$ = of(jobsSlice.actions.incDownloadStatus({ jobId: '1' }));
+    const result = await firstValueFrom(
+      incDownloadStatusEpic(action$, { value: state } as any, {} as any).pipe(
+        toArray(),
+      ),
+    );
+    expect(result).toEqual([
+      jobsSlice.actions.finishDownload({ jobId: '1' }),
+      jobsSlice.actions.saveAs({ jobId: '1' }),
+    ]);
+  });
+});
+

--- a/src/core/test/root-epic.test.ts
+++ b/src/core/test/root-epic.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { createRootEpic } from '../src/controllers/root-epic.ts';
+import { jobsSlice } from '../src/store/slices/index.ts';
+
+describe('root epic', () => {
+  it('runs child epics', async () => {
+    const rootEpic = createRootEpic();
+    const action$ = of(jobsSlice.actions.cancel({ jobId: '1' }));
+    const result = await firstValueFrom(
+      rootEpic(action$, { value: {} } as any, { fs: {} } as any),
+    );
+    expect(result).toEqual(jobsSlice.actions.delete({ jobId: '1' }));
+  });
+});
+

--- a/src/core/test/save-as-job-epic.test.ts
+++ b/src/core/test/save-as-job-epic.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { of, firstValueFrom } from 'rxjs';
+import { saveAsJobEpic } from '../src/controllers/save-as-job-epic.ts';
+import { jobsSlice } from '../src/store/slices/index.ts';
+import { Job } from '../src/entities/index.ts';
+
+describe('saveAsJobEpic', () => {
+  it('saves job to file and emits success', async () => {
+    const job = new Job('1', [], [], 'file.mp4', Date.now());
+    const fs = {
+      getBucket: vi.fn().mockResolvedValue({
+        getLink: vi.fn().mockResolvedValue('link'),
+      }),
+      saveAs: vi.fn().mockResolvedValue(undefined),
+    };
+    const action$ = of(jobsSlice.actions.saveAs({ jobId: '1' }));
+    const state = {
+      jobs: { jobs: { '1': job } },
+      config: { saveDialog: true },
+    };
+    const result = await firstValueFrom(
+      saveAsJobEpic(action$, { value: state } as any, { fs } as any),
+    );
+    expect(fs.saveAs).toHaveBeenCalledWith('file.mp4', 'link', { dialog: true });
+    expect(result).toEqual(
+      jobsSlice.actions.saveAsSuccess({ jobId: '1', link: 'link' }),
+    );
+  });
+});
+

--- a/src/core/test/slices.test.ts
+++ b/src/core/test/slices.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { configSlice, jobsSlice, levelsSlice, playlistsSlice, tabsSlice } from '../src/store/slices/index.ts';
+import { Level, Fragment, Key, Job, Playlist } from '../src/entities/index.ts';
+
+describe('store slices', () => {
+  it('config slice reducers', () => {
+    let state = configSlice.reducer(undefined, { type: 'init' } as any);
+    state = configSlice.reducer(state, configSlice.actions.setConcurrency({ concurrency: 5 }));
+    expect(state.concurrency).toBe(5);
+    state = configSlice.reducer(state, configSlice.actions.setSaveDialog({ saveDialog: true }));
+    expect(state.saveDialog).toBe(true);
+    state = configSlice.reducer(state, configSlice.actions.setFetchAttempts({ fetchAttempts: 10 }));
+    expect(state.fetchAttempts).toBe(10);
+  });
+
+  it('jobs slice reducers', () => {
+    const fragment = new Fragment(new Key(null, null), 'u', 0);
+    const job = new Job('1', [fragment], [], 'f', Date.now());
+    let state = jobsSlice.reducer(undefined, { type: 'init' } as any);
+    state = jobsSlice.reducer(state, jobsSlice.actions.add({ job }));
+    expect(state.jobs['1']).toBe(job);
+    expect(state.jobsStatus['1']!.total).toBe(1);
+    state = jobsSlice.reducer(state, jobsSlice.actions.incDownloadStatus({ jobId: '1' }));
+    expect(state.jobsStatus['1']!.done).toBe(1);
+    state = jobsSlice.reducer(state, jobsSlice.actions.saveAs({ jobId: '1' }));
+    expect(state.jobsStatus['1']!.status).toBe('saving');
+    state = jobsSlice.reducer(state, jobsSlice.actions.saveAsSuccess({ jobId: '1', link: 'l' }));
+    expect(state.jobs['1']!.link).toBe('l');
+    expect(state.jobsStatus['1']!.status).toBe('done');
+    state = jobsSlice.reducer(state, jobsSlice.actions.setSaveProgress({ jobId: '1', progress: 50, message: 'm' }));
+    expect(state.jobsStatus['1']!.saveProgress).toBe(50);
+    expect(state.jobsStatus['1']!.saveMessage).toBe('m');
+    state = jobsSlice.reducer(state, jobsSlice.actions.deleteSuccess({ jobId: '1' }));
+    expect(state.jobs['1']).toBeUndefined();
+    expect(state.jobsStatus['1']).toBeUndefined();
+  });
+
+  it('levels slice reducers', () => {
+    const level1 = new Level('stream', 'l1', 'p', 'u1');
+    const level2 = new Level('stream', 'l2', 'p', 'u2');
+    let state = levelsSlice.reducer(undefined, { type: 'init' } as any);
+    state = levelsSlice.reducer(state, levelsSlice.actions.add({ levels: [level1, level2] }));
+    expect(state.levels['l1']).toBe(level1);
+    state = levelsSlice.reducer(state, levelsSlice.actions.removePlaylistLevels({ playlistID: 'p' }));
+    expect(state.levels['l1']).toBeUndefined();
+  });
+
+  it('playlists slice reducers', () => {
+    const playlist = new Playlist('p1', 'uri', Date.now());
+    let state = playlistsSlice.reducer(undefined, { type: 'init' } as any);
+    state = playlistsSlice.reducer(state, playlistsSlice.actions.addPlaylist(playlist));
+    expect(state.playlists['p1']).toBe(playlist);
+    expect(state.playlistsStatus['p1']!.status).toBe('init');
+    state = playlistsSlice.reducer(state, playlistsSlice.actions.fetchPlaylistLevels({ playlistID: 'p1' }));
+    expect(state.playlistsStatus['p1']!.status).toBe('fetching');
+    state = playlistsSlice.reducer(state, playlistsSlice.actions.fetchPlaylistLevelsSuccess({ playlistID: 'p1' }));
+    expect(state.playlistsStatus['p1']!.status).toBe('ready');
+    state = playlistsSlice.reducer(state, playlistsSlice.actions.removePlaylist({ playlistID: 'p1' }));
+    expect(state.playlists['p1']).toBeUndefined();
+  });
+
+  it('tabs slice reducer', () => {
+    let state = tabsSlice.reducer(undefined, { type: 'init' } as any);
+    state = tabsSlice.reducer(state, tabsSlice.actions.setTab({ tab: { id: 5 } }));
+    expect(state.current.id).toBe(5);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for all core controller epics
- cover add/download job pipeline, playlist level fetching, job progress, saving, and root orchestration

## Testing
- `pnpm --filter @hls-downloader/core test --run`
- `sh ./scripts/build.sh`
