### PR TITLE
Add IndexedDBFS tests and test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Google removed the extension from the Chrome Web Store following a claim:
 5. Built files will be at `./dist/`
 6. The zip archive will be in `./extension-archive.zip`
 
+### Tests
+
+Run `sh ./scripts/test.sh` to execute unit tests across all packages.
+
 ### Development
 
 Run `make dev` to start watchers for all packages while you edit. The

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@videojs/vhs-utils':
         specifier: ^1.3.0
         version: 1.3.0
+      fake-indexeddb:
+        specifier: ^6.0.1
+        version: 6.0.1
       idb:
         specifier: 6.1.2
         version: 6.1.2
@@ -66,6 +69,9 @@ importers:
       vite:
         specifier: '>=5.4.17'
         version: 7.0.6(@types/node@20.19.0)(jiti@1.21.7)(terser@5.43.1)(yaml@2.8.0)
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/node@20.19.0)(jiti@1.21.7)(terser@5.43.1)(yaml@2.8.0)
 
   src/core:
     dependencies:
@@ -3121,6 +3127,10 @@ packages:
   extract-zip@1.7.0:
     resolution: {integrity: sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==}
     hasBin: true
+
+  fake-indexeddb@6.0.1:
+    resolution: {integrity: sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==}
+    engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -8969,6 +8979,8 @@ snapshots:
       yauzl: 2.10.0
     transitivePeerDependencies:
       - supports-color
+
+  fake-indexeddb@6.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,3 @@
+(pnpm install)
+(pnpm --filter ./src/core run test)
+(pnpm --filter ./src/background run test)

--- a/src/background/package.json
+++ b/src/background/package.json
@@ -11,18 +11,21 @@
   ],
   "scripts": {
     "dev": "vite build -w",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/webextension-polyfill": "0.10.0",
     "@videojs/vhs-utils": "^1.3.0",
+    "fake-indexeddb": "^6.0.1",
     "idb": "6.1.2",
     "m3u8-parser": "^6.2.0",
     "prettier": "2.8.7",
     "typescript": "5.3.3",
     "url-toolkit": "^2.1.6",
     "uuid": "^7.0.3",
-    "vite": "5.2.10"
+    "vite": "5.2.10",
+    "vitest": "3.2.4"
   },
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.10",

--- a/src/background/test/indexeddb-fs.test.ts
+++ b/src/background/test/indexeddb-fs.test.ts
@@ -1,0 +1,35 @@
+import 'fake-indexeddb/auto';
+import { vi, describe, it, expect } from 'vitest';
+vi.mock('webextension-polyfill', () => ({ downloads: { download: vi.fn() } }));
+import { IndexedDBFS } from '../src/services/indexedb-fs';
+
+const streamToArray = async (stream: ReadableStream<Uint8Array>) => {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+};
+
+describe('IndexedDBFS', () => {
+  it('writes and reads data through a bucket stream and deletes the bucket', async () => {
+    const id = 'bucket1';
+    await IndexedDBFS.createBucket(id, 0, 0);
+    const bucket = await IndexedDBFS.getBucket(id);
+    expect(bucket).toBeDefined();
+
+    await bucket!.write(0, new Uint8Array([1, 2]).buffer);
+    await bucket!.write(1, new Uint8Array([3, 4]).buffer);
+
+    const chunks = await streamToArray(await bucket!.stream());
+    expect(chunks).toHaveLength(2);
+    expect(Array.from(chunks[0])).toEqual([1, 2]);
+    expect(Array.from(chunks[1])).toEqual([3, 4]);
+
+    await IndexedDBFS.deleteBucket(id);
+    expect(await IndexedDBFS.getBucket(id)).toBeUndefined();
+  });
+});

--- a/src/background/vitest.config.ts
+++ b/src/background/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts']
+  }
+});

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "tsc -w",
     "build": "tsc",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/node": "20.19.0",


### PR DESCRIPTION
## Summary
- add unit test for IndexedDBFS service
- add script to run tests across workspace and document it in README
- enable vitest run scripts for core and background packages

## Testing
- `sh scripts/test.sh`
- `sh scripts/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_688fc3716bec8324882f66bffa456535