### PR TITLE
Refactor build system for incremental browser packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,25 @@
-.PHONY: install build dev clean storybook
+.PHONY: build dev clean
 
-install:
-	pnpm install
+SRC_FILES := $(shell find src -type f)
+SCRIPTS := $(wildcard scripts/*.sh)
+BUILD_STAMP := dist/.build-stamp
+FIREFOX := extension-firefox.xpi
+CHROME := extension-chrome.zip
 
-build:
+build: $(CHROME) $(FIREFOX)
+
+$(CHROME): $(BUILD_STAMP)
+	zip -r -FS $@ dist/
+
+$(FIREFOX): $(BUILD_STAMP)
+	cd dist && zip -r -FS ../$@ *
+
+$(BUILD_STAMP): $(SRC_FILES) $(SCRIPTS) package.json pnpm-lock.yaml
 	sh ./scripts/build.sh
+	touch $@
 
-dev:
+dev: $(CHROME) $(FIREFOX)
 	sh ./scripts/dev.sh
 
 clean:
-	sh ./scripts/clean.sh
-
-storybook:
-	sh ./scripts/storybook.sh
+	rm -rf dist $(CHROME) $(FIREFOX) $(BUILD_STAMP)

--- a/README.md
+++ b/README.md
@@ -53,14 +53,13 @@ Google removed the extension from the Chrome Web Store following a claim:
 3. Run `pnpm install`
 4. Run `make build` (or `sh ./scripts/build.sh`) and verify it completes without errors
 5. Built files will be at `./dist/`
-6. The zip archive will be in `./extension-archive.zip`
+6. Packaged extensions will be created as `extension-chrome.zip` and `extension-firefox.xpi`
 
 ### Development
 
 Run `make dev` to start watchers for all packages while you edit. The
-compiled extension will appear in `dist/` as you work.
-
-Run `make storybook` to launch Storybook for previewing popup and design-system components.
+command ensures the Chrome `.zip` and Firefox `.xpi` archives are up to date
+before launching watch mode.
 
 ## Project Structure
 

--- a/scripts/build-background.sh
+++ b/scripts/build-background.sh
@@ -1,1 +1,0 @@
-pnpm --filter ./src/background run build

--- a/scripts/build-core.sh
+++ b/scripts/build-core.sh
@@ -1,1 +1,0 @@
-pnpm --filter ./src/core run build

--- a/scripts/build-design-system.sh
+++ b/scripts/build-design-system.sh
@@ -1,1 +1,0 @@
-pnpm --filter ./src/design-system run build

--- a/scripts/build-extension.sh
+++ b/scripts/build-extension.sh
@@ -1,5 +1,0 @@
-(sh ./scripts/copy-assets.sh) &
-(sh ./scripts/build-background.sh) &
-(sh ./scripts/build-popup.sh) &
-
-wait

--- a/scripts/build-popup.sh
+++ b/scripts/build-popup.sh
@@ -1,1 +1,0 @@
-pnpm --filter ./src/popup run build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,16 @@
-(sh ./scripts/clean.sh)
-(sh ./scripts/build-core.sh)
-(sh ./scripts/build-design-system.sh)
-(sh ./scripts/build-extension.sh)
-(zip -r extension-chrome.zip ./dist/.)
-(cd ./dist && zip -r ../extension-firefox.xpi *)
+#!/bin/sh
+set -e
+pnpm install
+rm -rf dist extension-chrome.zip extension-firefox.xpi
+mkdir -p dist
+# Build shared packages first
+(pnpm --filter ./src/core run build) &
+(pnpm --filter ./src/design-system run build) &
+wait
+# Then build extension pieces
+(pnpm --filter ./src/background run build) &
+(pnpm --filter ./src/popup run build) &
+wait
+cp -r src/assets/* dist/
+zip -r -FS extension-chrome.zip dist/
+(cd dist && zip -r -FS ../extension-firefox.xpi *)

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,3 +1,0 @@
-rm -rf dist
-mkdir dist
-rm -rf extension-archive.zip

--- a/scripts/copy-assets.sh
+++ b/scripts/copy-assets.sh
@@ -1,1 +1,0 @@
-cp -r ./src/assets/* ./dist/

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,7 +1,9 @@
-(sh ./scripts/copy-assets.sh) &
+#!/bin/sh
+set -e
+mkdir -p dist
+cp -r src/assets/* dist/
 (pnpm --filter ./src/core run dev) &
 (pnpm --filter ./src/design-system run dev) &
 (pnpm --filter ./src/background run dev) &
 (pnpm --filter ./src/popup run dev) &
-
 wait

--- a/scripts/storybook.sh
+++ b/scripts/storybook.sh
@@ -1,1 +1,0 @@
-pnpm --filter ./src/popup run storybook


### PR DESCRIPTION
## Summary
- streamline build and dev scripts by removing redundant helpers and embedding clean and asset copy steps
- extend Makefile so `make dev` builds both Chrome and Firefox archives before launching watchers
- document that development mode now produces Chrome and Firefox packages

## Testing
- `pnpm install`
- `make build`
