### PR TITLE
docs: expand guides and developer portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,73 @@
 
 ![](https://github.com/puemos/hls-downloader/blob/master/src/extension/store-assets/png/Small-Promo-Tile.png?raw=true)
 
-Capture and download [HTTP Live streams (HLS)](https://en.wikipedia.org/wiki/HTTP\_Live\_Streaming) from your browser
+Capture and download [HTTP Live streams (HLS)](https://en.wikipedia.org/wiki/HTTP_Live_Streaming)
+from your browser.
 
 This extension is completely free and published under the MIT license.
 
-###
+## Features
+
+- Detects HLS playlists from any tab
+- Accepts manual playlist URLs when detection fails
+- Lets you pick specific video and audio tracks
+- Merges segments into a single MP4 using bundled `ffmpeg.wasm`
+- Tracks active and completed downloads in a dedicated tab
+- Offers concurrency, retry, and save dialog options
+- Works entirely in your browser with no external dependencies
+
+## Get it
+
+### Firefox
+
+[![Firefox](https://blog.mozilla.org/addons/files/2015/11/get-the-addon.png)](https://addons.mozilla.org/en-US/firefox/addon/hls-downloader/)
+
+A signed `extension-firefox.xpi` is available on the [releases page](https://github.com/puemos/hls-downloader/releases) for manual installation.
+
+### Microsoft Edge
+
+[![Microsoft Edge](https://developer.microsoft.com/store/badges/images/English_get-it-from-MS.png)](https://microsoftedge.microsoft.com/addons/detail/hls-downloader/ldehhnlpcedapncohebgmghanffggffc)
+
+### Google
+
+Google removed the extension from the Chrome Web Store following a copyright
+claim from Globo Comunicação e Participações SA. Chrome and Brave users can
+sideload the extension using the `extension-chrome.zip` archive from the
+[releases page](https://github.com/puemos/hls-downloader/releases). Extract it
+and follow [Install the extension](guides/install-the-extension.md) for
+step-by-step instructions.
+
+## Usage
+
+1. Browse to a page that plays an HLS video and start playback.
+2. Click the **HLS Downloader** icon and choose a playlist from the **Sniffer**
+   tab. If nothing appears, switch to **Direct** and paste the playlist URL.
+3. Pick the desired video and audio streams and press **Download**.
+4. Monitor progress in the **Downloads** tab. Once merging completes, your
+   browser will prompt you to save the file.
+
+## Project structure
+
+The extension is split into multiple packages under `src/`:
+
+```
+src/
+├── assets          # extension manifest and icons
+├── background      # background scripts
+├── core            # shared logic and Redux store
+├── design-system   # UI component library
+└── popup           # React popup UI
+```
+
+See [development/architecture.md](development/architecture.md) for a deeper
+look at the codebase.
+
+## Build
+
+See [development/build.md](development/build.md) for build and development
+instructions.
+
+## License
+
+MIT
+

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,11 +5,14 @@
 ## 😎 Guides
 
 * [Install the extension](guides/install-the-extension.md)
-* [Capture a steam](guides/capture-a-steam.md)
+* [Capture a stream](guides/capture-a-stream.md)
+* [Download from a direct link](guides/download-from-a-direct-link.md)
+* [Configure settings](guides/configure-settings.md)
 
 ## 👩‍💻 Development
 
 * [Build](development/build.md)
+* [Architecture](development/architecture.md)
 * [Contributing](development/contributing.md)
 
 ## 🏦 Legal

--- a/development/architecture.md
+++ b/development/architecture.md
@@ -1,0 +1,36 @@
+# Architecture
+
+HLS Downloader follows the structure of [browser-extension-template](https://github.com/puemos/browser-extension-template) and is organized as a pnpm workspace. Each package under `src/` encapsulates a portion of the extension:
+
+## Packages
+
+- **assets** – extension manifest, icons and other static files
+- **core** – domain logic and the Redux store shared across apps
+- **background** – background scripts that sniff network requests and orchestrate downloads
+- **popup** – the React UI shown when the toolbar button is clicked
+- **design-system** – reusable React components and styles
+
+## Core domain
+
+The `core` package implements the business layer in a domain-driven style:
+
+- **Entities** – classes representing HLS concepts such as `Fragment` and `Key`
+- **Use cases** – single business actions composed from entities and services
+- **Services** – interfaces for side effects like fetching or storage; concrete implementations live in other packages
+- **Controllers** – RxJS epics that react to Redux actions and chain use cases
+- **Store** – Redux Toolkit slices wired together and exposed through WebExt Redux so background and UI share state
+
+## Apps
+
+### Background
+
+The background app wires browser APIs to the core store. Listeners watch for tab changes and network requests, dispatch actions, and fulfill services such as fetching segment data or writing files to disk.
+
+### Popup
+
+The popup app is a React single-page application built on the design system. It connects to the shared store to show detected playlists, manage downloads, and update settings.
+
+## Build and testing
+
+Build scripts compile each package with Vite, copy `assets`, and output to `dist/`. After a successful build, archives `extension-chrome.zip` and `extension-firefox.xpi` are generated. Unit tests run across packages with `pnpm test`; coverage is produced with `pnpm test:coverage`. `pnpm storybook` launches an isolated component explorer for the design system.
+

--- a/development/build.md
+++ b/development/build.md
@@ -1,7 +1,24 @@
 # Build
 
-1. Clone the repo
-2. Ensure you have node, npm installed
-3. Run `sh ./build.sh`
-4. Raw files will be at `./src/extension/dist/`
-5. The zip will be in `./extension-archive.zip`
+1. Clone the repo.
+2. Install Node.js (v18 or newer) and `pnpm` 10 or later.
+3. Run `pnpm install` to install all dependencies.
+4. Run `pnpm build` and verify it completes without errors.
+5. Built files will be in `./dist/`.
+6. The packaged archives will be `./extension-chrome.zip` and
+   `./extension-firefox.xpi`.
+7. Load `dist/` as an unpacked extension in your browser to test the build
+   locally.
+
+## Tests
+
+Run `pnpm test` to execute unit tests across all packages. For a combined
+coverage report and badge, run `pnpm test:coverage`.
+
+## Development
+
+Run `pnpm dev` to start watchers for all packages while you edit. The compiled
+extension will appear in `dist/` as you work. To preview popup and
+design-system components, run `pnpm storybook`.
+
+See [architecture](architecture.md) for an overview of the project structure.

--- a/development/contributing.md
+++ b/development/contributing.md
@@ -1,13 +1,18 @@
 # Contributing
 
-When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
+When contributing to this repository, please first discuss the change you wish
+to make via issue, email, or any other method with the owners of this
+repository before making a change.
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Please note we have a [Code of Conduct](../legal/code_of_conduct.md); please
+follow it in all your interactions with the project.
 
 ## Pull Request Process
 
-1. Ensure any install or build dependencies are removed before the end of the layer when doing a build.
-2. Update the README.md with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations, and container parameters.
-3. Increase the version numbers in any examples files and the README.md to the new version that this Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-4. You may merge the Pull Request once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+1. Fork the project and create your branch from `master`.
+2. Run `pnpm test` and `pnpm build` to ensure the project passes tests and
+   builds.
+3. Update documentation, examples and any relevant files alongside your code.
+4. Submit a pull request and request a review. Once approved, a maintainer will
+   merge it for you.
 

--- a/guides/capture-a-steam.md
+++ b/guides/capture-a-steam.md
@@ -1,9 +1,0 @@
-# Capture a steam
-
-1. Visit the page where the video is streaming
-2. Play the video
-3. Click on the extension's icon
-4. Find the right stream
-5. Choose the quality
-6. Hit the download
-7. Wait for the download to finish

--- a/guides/capture-a-stream.md
+++ b/guides/capture-a-stream.md
@@ -1,0 +1,21 @@
+# Capture a stream
+
+This guide walks through saving a video that is delivered using the HLS
+protocol.
+
+1. Browse to a page that plays an HLS video and start playback.
+2. Click the **HLS Downloader** icon. Detected playlists will appear in the
+   **Sniffer** tab.
+3. Choose **Select** next to the playlist you want to download. If multiple
+   variants are available, pick the one that matches your desired quality.
+4. Pick the video and audio streams from the playlist view. You can download
+   either muxed or separate tracks.
+5. Press **Download**. The extension fetches all segments and automatically
+   merges them into a single MP4 using the bundled `ffmpeg.wasm`.
+6. Track progress in the **Downloads** tab and keep the page open while
+   merging completes. When the process finishes, your browser will prompt you
+   to save the merged file.
+
+`ffmpeg` support is bundled with the extension so no external dependencies are
+required. Longer videos may take additional time to merge depending on your
+hardware.

--- a/guides/configure-settings.md
+++ b/guides/configure-settings.md
@@ -1,0 +1,10 @@
+# Configure settings
+
+Adjust how the extension downloads and saves streams.
+
+1. Click the **HLS Downloader** icon and open the **Settings** tab.
+2. Use **Concurrency** to control how many segments download in parallel. Higher values may speed up downloads on fast connections.
+3. Change **Fetch Attempts** to set how many times the extension retries a failed segment.
+4. Toggle **Save Dialog** to choose whether the browser asks where to save each file.
+
+Tweaking these options lets you balance reliability and speed for your network and workflow.

--- a/guides/download-from-a-direct-link.md
+++ b/guides/download-from-a-direct-link.md
@@ -1,0 +1,10 @@
+# Download from a direct link
+
+If the extension doesn't automatically detect a playlist, you can add one manually.
+
+1. Click the **HLS Downloader** icon and switch to the **Direct** tab.
+2. Paste the HLS playlist URL (ending in `.m3u8`) into the input and press **Add**.
+3. Select the playlist from the list and choose the video and audio streams you want.
+4. Hit **Download** to fetch the segments and merge them into a single MP4.
+
+This workflow mirrors a captured stream, letting you save videos even when sniffing fails.

--- a/guides/install-the-extension.md
+++ b/guides/install-the-extension.md
@@ -1,30 +1,42 @@
 # Install the extension
 
-The extension is available for Firefox and Microsoft Edge from the extension marketplace. In case you are using Chrome, Brave will need to download a `crx` file and install it manually (guide).
+The extension is available for Firefox and Microsoft Edge through their
+respective stores. Chrome and Brave users must sideload the extension using
+the `extension-chrome.zip` archive from the [releases page](https://github.com/puemos/hls-downloader/releases).
+A signed `extension-firefox.xpi` is also provided for manual Firefox installs.
 
 {% tabs %}
 {% tab title="Chrome" %}
-1. Download the `hls-downloader.crx` file from the latest release ([https://github.com/puemos/hls-downloader/releases](https://github.com/puemos/hls-downloader/releases))
-2. Open `chrome://extensions/`
-3. Enable `Developer mode`
-4. Drop the `hls-downloader.crx` file into the page
-5. Enjoy :)
+1. Download `extension-chrome.zip` from the [latest release](https://github.com/puemos/hls-downloader/releases).
+2. Extract the archive to a folder.
+3. Open `chrome://extensions/`.
+4. Enable **Developer mode**.
+5. Click **Load unpacked** and select the extracted folder.
+6. Verify the extension appears in the list and start browsing.
 {% endtab %}
 
 {% tab title="Brave" %}
-1. Download the `hls-downloader.crx` file from the latest release ([https://github.com/puemos/hls-downloader/releases](https://github.com/puemos/hls-downloader/releases))
-2. Open `chrome://extensions/`
-3. Enable `Developer mode`
-4. Drop the `hls-downloader.crx` file into the page
-5. Enjoy :)
+1. Download `extension-chrome.zip` from the [latest release](https://github.com/puemos/hls-downloader/releases).
+2. Extract the archive to a folder.
+3. Open `brave://extensions/`.
+4. Enable **Developer mode**.
+5. Click **Load unpacked** and select the extracted folder.
+6. Confirm the extension is enabled in the toolbar.
 {% endtab %}
 
 {% tab title="Firefox" %}
-[![firefox](https://camo.githubusercontent.com/805d144f4ff52dc0832bef30f88ebdedd31071c20199a24c54e33d22f09d82dc/68747470733a2f2f626c6f672e6d6f7a696c6c612e6f72672f6164646f6e732f66696c65732f323031352f31312f6765742d7468652d6164646f6e2e706e67)](https://addons.mozilla.org/en-US/firefox/addon/hls-downloader/statistics/?last=30)
+[![firefox](https://camo.githubusercontent.com/805d144f4ff52dc0832bef30f88ebdedd31071c20199a24c54e33d22f09d82dc/68747470733a2f2f626c6f672e6d6f7a696c6c612e6f72672f6164646f6e732f66696c65732f323031352f31312f6765742d7468652d6164646f6e2e706e67)](https://addons.mozilla.org/en-US/firefox/addon/hls-downloader/)
+
+Or install the XPI manually:
+
+1. Download `extension-firefox.xpi` from the [latest release](https://github.com/puemos/hls-downloader/releases).
+2. Open `about:addons` in Firefox.
+3. Click the gear icon and choose **Install Add-on From File...**.
+4. Select the downloaded file and approve the prompts.
 {% endtab %}
 
 {% tab title="Microsoft Edge" %}
-[![Microsoft Edge](https://developer.microsoft.com/store/badges/images/English\_get-it-from-MS.png)](https://microsoftedge.microsoft.com/addons/detail/hls-downloader/ldehhnlpcedapncohebgmghanffggffc)
+[![Microsoft Edge](https://developer.microsoft.com/store/badges/images/English_get-it-from-MS.png)](https://microsoftedge.microsoft.com/addons/detail/hls-downloader/ldehhnlpcedapncohebgmghanffggffc)
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
## Summary
- describe features, sideload instructions, and project structure in README
- add architecture overview and expand build guide with prerequisites and dev tips
- clarify browser installation steps and capture workflow in user guides
- document direct-link downloads, configurable settings, and the Downloads tab
- elaborate architecture guide with domain-driven core and app responsibilities
- update install docs for `extension-chrome.zip` and `extension-firefox.xpi`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/hls-downloader/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689246e59d0083249ecc9de8195e98c0